### PR TITLE
Add -ni flag to the listRelatives command

### DIFF
--- a/modules/brSmoothWeights/scripts/brTransferWeightsInfluenceList.mel
+++ b/modules/brSmoothWeights/scripts/brTransferWeightsInfluenceList.mel
@@ -206,7 +206,7 @@ global proc brTransferWeightsGetSelection()
     string $skin;
     if (`nodeType $node[0]` == "transform")
     {
-        string $shape[] = `listRelatives -shapes -ni -fullPath $node[0]`;
+        string $shape[] = `listRelatives -shapes -noIntermediate -fullPath $node[0]`;
         if (size($shape) == 0)
         {
             brTransferWeightsClear;

--- a/modules/brSmoothWeights/scripts/brTransferWeightsInfluenceList.mel
+++ b/modules/brSmoothWeights/scripts/brTransferWeightsInfluenceList.mel
@@ -206,7 +206,7 @@ global proc brTransferWeightsGetSelection()
     string $skin;
     if (`nodeType $node[0]` == "transform")
     {
-        string $shape[] = `listRelatives -shapes -fullPath $node[0]`;
+        string $shape[] = `listRelatives -shapes -ni -fullPath $node[0]`;
         if (size($shape) == 0)
         {
             brTransferWeightsClear;


### PR DESCRIPTION
Maya 2017 Update 5 - Windows 10 Pro x64

Paint Transfer Weights Tool Issue.

I have a referenced geometry with is bound in my main scene, this geo also comes with a blenShape. So the issue I was facing is that the procedure did not return a valid skinCluster due to the fact that intermediate objects were present in the listRelatives output. This caused the failure of the listHistory command used later.

On a side note, when you try to run any of the tools contained in the plugin without a mesh deformed by skinCluster selected this errors show up in the Output Window, Do not know if this for debbuging but I think they are not necessary in the release version:

![imagen](https://user-images.githubusercontent.com/2865181/50354208-0a007900-054b-11e9-9bec-732778893fd2.png)

API error detected in smoothWeightsTool.cpp at line 832
: (kNotFound): Unexpected Internal Failure

API error detected in transferWeightsTool.cpp at line 1271
: (kNotFound): Unexpected Internal Failure


Thanks for these incredibly useful tools. Much appreciated and keep up the good work. 
Cheers

Carlos Rico Adega